### PR TITLE
Fix broken links + Clarify custom Spoofax

### DIFF
--- a/project/ms1/faq.md
+++ b/project/ms1/faq.md
@@ -15,7 +15,7 @@ subcontext: ms1
 
 If you get the error "Unable to access the language under test: 'minijava'", then please do the following:
 
-1. Check that you are using the latest version fo Spoofax Eclipse (at the moment: 2.6.0.xxxxxxxx-xxxxxx-cs4200) by going to *Help* > *About Eclipse* > *Installation Details* (On MacOS the *About* is under the left-hand menu named *Eclipse*). If you are using an older version, please download the newest version (again) as per the [instructions](/assignments/ms1/).
+1. Check that you are using the latest version of Spoofax Eclipse (at the moment: 2.6.0.xxxxxxxx-xxxxxx-cs4200, which can be downloaded [here](/documentation/spoofax.html) and NOT on the official Spoofax website) by going to *Help* > *About Eclipse* > *Installation Details* (On MacOS the *About* is under the left-hand menu named *Eclipse*). If you are using an older version, please download the newest version (again) as per the [instructions](/documentation/spoofax.html).
 2. Make sure the path to your Spoofax installation does not contain a space! If this is the case, move your Spoofax installation to a location without a space.
 3. Clean and build all projects (through *Project* > *Clean*, *Project* > *Build All*). You can see what's going on by opening the console (*Window* > *Show View* > *Console*).
 4. Finally, close and re-open any test files that were already open.
@@ -38,7 +38,7 @@ Check that INT and ID are defined as `context-free start symbol` (even though th
 
 ##### After importing the projects into Eclipse I receive several errors that have to do with importing and including files.
 
-If you get errors after [importing the projects into Eclipse](/assignments/ms1/lab1.html#importing-projects-into-eclipse) you should build the project by choosing *Project > Build All* from the menu.
+If you get errors after [importing the projects into Eclipse](/project/ms1/lab1.html#importing-projects-into-eclipse) you should build the project by choosing *Project > Build All* from the menu.
 
 
 # Syntax Definition

--- a/project/ms1/faq.md
+++ b/project/ms1/faq.md
@@ -15,7 +15,7 @@ subcontext: ms1
 
 If you get the error "Unable to access the language under test: 'minijava'", then please do the following:
 
-1. Check that you are using the latest version of Spoofax Eclipse (at the moment: 2.6.0.xxxxxxxx-xxxxxx-cs4200, which can be downloaded [here](/documentation/spoofax.html) and NOT on the official Spoofax website) by going to *Help* > *About Eclipse* > *Installation Details* (On MacOS the *About* is under the left-hand menu named *Eclipse*). If you are using an older version, please download the newest version (again) as per the [instructions](/documentation/spoofax.html).
+1. Check that you are using the latest version of Spoofax Eclipse (at the moment: 2.6.0.xxxxxxxx-xxxxxx-cs4200, which can be downloaded [here](/documentation/spoofax.html) and **not** on the official Spoofax website) by going to *Help* > *About Eclipse* > *Installation Details* (On MacOS the *About* is under the left-hand menu named *Eclipse*). If you are using an older version, please download the newest version (again) as per the [instructions](/documentation/spoofax.html).
 2. Make sure the path to your Spoofax installation does not contain a space! If this is the case, move your Spoofax installation to a location without a space.
 3. Clean and build all projects (through *Project* > *Clean*, *Project* > *Build All*). You can see what's going on by opening the console (*Window* > *Show View* > *Console*).
 4. Finally, close and re-open any test files that were already open.


### PR DESCRIPTION
- Clarify the usage of a custom Spoofax version. It is not clear that this can not be downloaded from the original Spoofax website.
- Fix broken links due to "assignments" being renamed to "project".