### PR TITLE
Fix typo and indentation in lab8.md

### DIFF
--- a/project/ms2/lab8.md
+++ b/project/ms2/lab8.md
@@ -116,7 +116,7 @@ If you get an error about `Resource '/.org.eclipse.jdt.core.external.folders' al
 
 ### Control-flow
 
-Control-flow is specified as control-flow rules in `.flo` files. FlowSpec files must go in the `trans/analysis` directory. The module name at the top of the file should match the filename relative to `trans`. For example, the file `trans/analysis/control.flow` starts as:
+Control-flow is specified as control-flow rules in `.flo` files. FlowSpec files must go in the `trans/analysis` directory. The module name at the top of the file should match the filename relative to `trans`. For example, the file `trans/analysis/control.flo` starts as:
 
 ```
 module analysis/control

--- a/project/ms2/lab8.md
+++ b/project/ms2/lab8.md
@@ -127,7 +127,7 @@ module analysis/control
 The rules match on an AST constructor, and define the control-flow of that construct in terms of nodes, control-flow of the subtrees, and the surrounding control-flow graph. 
 
 ```
-  control-flow rules // Lists
+control-flow rules // Lists
 
   Cons(h, t) = entry -> h -> t -> exit
   Nil() = entry -> exit


### PR DESCRIPTION
The file name given in that assignment ends with `.flow`, but in the same paragraph, `.flo` is named as the proper extension, so I believe this to be an error. (Also, the file in the template branch has the `.flo` ending.)

_Update:_ I also spotted an indentation error, so I've fixed that one, as well.