### PR TITLE
Disambiguation of Lab 8

### DIFF
--- a/project/ms2/lab8.md
+++ b/project/ms2/lab8.md
@@ -230,4 +230,4 @@ Note that [there are data helpers strategies for FlowSpec](http://www.metaborg.o
 
 ### Challenge
 
-For the challenge we want a slightly different behavior from your implementation than Java. In Java a local variable _must_ be initialized before it can be used, anything else is an error. For this challenge, give a warning instead, iff the local variable is _possibly_ uninitialized at a use site. 
+For the challenge we want a slightly different behavior from your implementation than Java. In Java a local variable _must_ be initialized before it can be used, anything else is an error. For this challenge, give a warning instead, iff the local variable is _possibly_ uninitialized at a use site. Change the error message behavior to only raise errors when the local variable is _definitely_ unitialized at a use site.


### PR DESCRIPTION
As it stands, I find the challenge part of lab 8 to be ambiguous: "possibly uninitialized" is the same as "may be uninitialized", so it could be interpreted as the challenge being a mere switch from error reporting to warning reporting (which is trivial). However, I think that you mean to say that warnings should only be raised for "maybe" cases and not "definite" cases, while errors should be changed to only respond to "definite" cases. Am I interpreting this correctly?