### PR TITLE
Refer back to correct assignment in assignment 10/11

### DIFF
--- a/project/ms3/lab10.md
+++ b/project/ms3/lab10.md
@@ -178,7 +178,7 @@ For grading, if you decide not to participate in the challenge, use a fixed stac
 ### Testing and Debugging
 
 Testing and debugging your compiler is the same as the previous lab.
-Refer to the section on [Testing and Debugging from assignment 8](lab8.html#testing-and-debugging).
+Refer to the section on [Testing and Debugging from assignment 9](lab9.html#testing-and-debugging).
 
 ## Challenges
 

--- a/project/ms3/lab11.md
+++ b/project/ms3/lab11.md
@@ -157,4 +157,4 @@ You now need to extend your code generator to handle method parameters and local
 ### Testing and Debugging
 
 Testing and debugging your compiler is the same as previous labs.
-Refer to the section on [Testing and Debugging from assignment 8](lab8.html#testing-and-debugging).
+Refer to the section on [Testing and Debugging from assignment 9](lab9.html#testing-and-debugging).


### PR DESCRIPTION
Because of the new assignment this year, the reference to the first code generation assignment was no longer correct. This PR changes the link/name to assignment 9 .

A side note: Since the templates etc. have already been released I think the under construction warnings can be removed in assignments 10/11.